### PR TITLE
Fixed a bad example in Custom Shaders

### DIFF
--- a/en/manual/graphics/effects-and-shaders/custom-shaders.md
+++ b/en/manual/graphics/effects-and-shaders/custom-shaders.md
@@ -127,8 +127,11 @@ For example, the code below defines and uses the dynamic parameter `Frequency`:
 ```cs
 shader ComputeColorWave: ComputeColor, Texturing
 {
-    stage float Frequency = 1.0f;
-
+    cbuffer PerMaterial
+    {
+        stage float Frequency = 1.0f;
+    }
+    
     override float4 Compute()
     {
         return sin(( Global.Time ) * 2 * 3.14 * Frequency);

--- a/en/manual/scripts/create-a-model-from-code.md
+++ b/en/manual/scripts/create-a-model-from-code.md
@@ -126,8 +126,8 @@ For example:
 	    }
     };
     var material = Material.New(GraphicsDevice, materialDescription);
-    material.Parameters.Set(MaterialKeys.DiffuseValue, Color.Red);
-    model.Materials.Add(material);
+    material.Parameters[0].Set(MaterialKeys.DiffuseValue, Color.Red);
+    model.Materials.Add(0, material);
 ```
 
 ## See also


### PR DESCRIPTION
I wasn't able to get a custom shader to work by following the example in the manual. After doing some research I found the exposed parameter needed to be in the PerMaterial block. This pull request updates the example to reflect that.

I'm not sure how or why the last line in the file has changed.